### PR TITLE
Fixing the name in the dylib for MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+libwdsp.a
+libwdsp.dylib

--- a/Makefile.mac
+++ b/Makefile.mac
@@ -212,6 +212,7 @@ $(JAVA_PROGRAM): $(JAVA_OBJS)
 
 install: $(PROGRAM)
 	cp wdsp.h /usr/local/include
+	install_name_tool -id /usr/local/lib/$(PROGRAM) $(PROGRAM)
 	cp $(PROGRAM) /usr/local/lib
 
 install_java: $(JAVA_PROGRAM)


### PR DESCRIPTION
This is necessary when bundling applications with libraries (e.g. making a MacOS "app" bundle for piHPSDR). The install_name_tool command simply plugs into the dynamic library where it actually
resides. Only Makefile.mac is affected.

BTW, I added a .gitignore. This facilitates everyday work.