### PR TITLE
Update for MacOS (semaphore handling)

### DIFF
--- a/Makefile.mac
+++ b/Makefile.mac
@@ -14,8 +14,9 @@ JAVA_LIBS=-L. -lwdsp
 
 #
 # You probably need to locate where the JAVA includes reside on *your* system
+# since the version number (here: 8.0_74) changes frequently.
 #
-INCLUDES=-I/usr/local/include -I/Library/Java/JavaVirtualMachines/jdk1.8.0_40.jdk/Contents/Home/Include -I/Library/Java/JavaVirtualMachines/jdk1.8.0_40.jdk/Contents/Home/Include/darwin
+INCLUDES=-I/usr/local/include -I/Library/Java/JavaVirtualMachines/jdk1.8.0_74.jdk/Contents/Home/Include -I/Library/Java/JavaVirtualMachines/jdk1.8.0_40.jdk/Contents/Home/Include/darwin
 
 COMPILE=$(CC) $(INCLUDES)
 

--- a/linux_port.c
+++ b/linux_port.c
@@ -91,6 +91,7 @@ int LinuxWaitForSingleObject(sem_t *sem,int ms) {
 }
 
 sem_t *LinuxCreateSemaphore(int attributes,int initial_count,int maximum_count,char *name) {
+        sem_t *sem;
 #ifdef __APPLE__
         //DL1YCF
 	//This routine is invoked with name=NULL several times, so we have to make
@@ -98,14 +99,18 @@ sem_t *LinuxCreateSemaphore(int attributes,int initial_count,int maximum_count,c
 	static int semcount=0;
 	char sname[12];
         sprintf(sname,"WDSP%05d",semcount++);
-        return sem_open(sname, O_CREAT, 0700, initial_count);
+	sem_unlink(sname);
+        sem=sem_open(sname, O_CREAT | O_EXCL, 0700, initial_count);
+	if (sem == SEM_FAILED) {
+	  perror("WDSP:CreateSemaphore");
+	}
 #else
         sem_t *sem;
         sem=malloc(sizeof(sem_t));
 	int result;
 	result=sem_init(sem, 0, 0);
-	return sem;
 #endif
+	return sem;
 }
 
 void LinuxReleaseSemaphore(sem_t* sem,int release_count, int* previous_count) {

--- a/linux_port.c
+++ b/linux_port.c
@@ -105,7 +105,6 @@ sem_t *LinuxCreateSemaphore(int attributes,int initial_count,int maximum_count,c
 	  perror("WDSP:CreateSemaphore");
 	}
 #else
-        sem_t *sem;
         sem=malloc(sizeof(sem_t));
 	int result;
 	result=sem_init(sem, 0, 0);


### PR DESCRIPTION
To make the use of named semaphores (required in MacOS) bullet-proof, they are now opened with exclusive access, and each sem_open() is preceeded by a sem_close() with the same name.
This avoids connecting to semaphores still lingering around in the OS.