### PR TITLE
Updated Makefile to be compatible with distro packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 #
 # libwdsp.so Makefile (Linux)
 #
+PREFIX=/usr/local
+LIBDIR=$(DESTDIR)$(PREFIX)/lib
+INCLUDEDIR=$(DESTDIR)$(PREFIX)/include
 CC=gcc
 LINK=gcc
 OPTIONS=-g -fPIC -O3 -D _GNU_SOURCE
@@ -213,24 +216,27 @@ all: $(PROGRAM) $(HEADERS) $(SOURCES)
 java: $(JAVA_PROGRAM) $(JAVA_HEADERS) $(JAVA_SOURCES)
 
 $(PROGRAM): $(OBJS)
-	$(LINK) -shared -z noexecstack -o $(PROGRAM) $(OBJS) $(LIBS) $(GTKLIBS)
+	$(LINK) -shared -z noexecstack $(LDFLAGS) -o $(PROGRAM) $(OBJS) $(LIBS) $(GTKLIBS)
 
 $(JAVA_PROGRAM): $(JAVA_OBJS)
-	$(LINK) -shared -z noexecstack -o $(JAVA_PROGRAM) $(JAVA_OBJS) $(JAVA_LIBS)
+	$(LINK) -shared -z noexecstack $(LDFLAGS) -o $(JAVA_PROGRAM) $(JAVA_OBJS) $(JAVA_LIBS)
 
 .c.o:
-	$(COMPILE) $(OPTIONS) $(GTKOPTIONS) -c -o $@ $<
+	$(COMPILE) $(OPTIONS) $(GTKOPTIONS) $(CFLAGS) -c -o $@ $<
 
-install: $(PROGRAM)
-	cp wdsp.h /usr/local/include
-	cp $(PROGRAM) /usr/local/lib
-	ldconfig
+install-dirs:
+	mkdir -p $(LIBDIR) $(INCLUDEDIR)
 
-install_java: $(JAVA_PROGRAM)
-	cp $(JAVA_PROGRAM) /usr/local/lib
+install: $(PROGRAM) install-dirs
+	cp -a wdsp.h $(INCLUDEDIR)
+	cp -a $(PROGRAM) $(LIBDIR)
+	ldconfig || :
+
+install_java: $(JAVA_PROGRAM) install-dirs
+	cp -a $(JAVA_PROGRAM) $(LIBDIR)
 
 release: $(PROGRAM)
-	cp $(PROGRAM) ../pihpsdr.src/release/pihpsdr
+	cp -a $(PROGRAM) ../pihpsdr.src/release/pihpsdr
 
 clean:
 	-rm -f *.o


### PR DESCRIPTION
I am trying to get wdsp and linhpsdr into Fedora. The proposed patch improves the Makefile to be suitable for the the distro packaging, the changes:
* used `cp -a` to preserve build timestamps (better would be to use `install -p`)
* honor distro's global CFLAGS and LDFLAGS
* allow install paths overrides by DESTDIR, PREFIX, LIBDIR, INCLUDEDIR
* do not fail if `ldconfig` fails, distro's build system can install as regular user, usually Makefiles don't call `ldconfig` and it's let on the distro

It would be also good to have SONAME, even SONAME libwdsp.so.0 would be good with the filename libwdsp.so.0.0.0 and appropriate symlinks. In Fedora it's mandatory to have SONAMEs, so I will add '0' by downstream patch. In case you are OK to add SONAME upstream, I can provide the patch.
