### PR TITLE
Add support for out-of-source build and auto-generated dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 
 JAVA_LIBS=-L. -lwdsp
 
-INCLUDES=-I $(JAVA_HOME)/include -I $(JAVA_HOME)/include/linux
+INCLUDES=-I $(JAVA_HOME)/include -I $(JAVA_HOME)/include/linux -I $(PREFIX)/include
 
 COMPILE=$(CC) $(INCLUDES) $(GTKINCLUDES)
 


### PR DESCRIPTION
This PR suggests
1. supporting for Out-of-source build via optional, externally provided BUILDDIR variable.
2. separating installation paths from the include/library search paths to enable staged builds

Usage example:
```
make -j$(nproc) BUILDDIR=/tmp/wdsp
sudo make install BUILDDIR=/tmp/wdsp
```